### PR TITLE
[CI] Limit CI to PRs and commits to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,4 @@
 language: ruby
+branches:
+  only:
+  - master


### PR DESCRIPTION
Should still build when a PR is opened but not when commits are
pushed to any other branch.