### PR TITLE
Create page title helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,4 +2,10 @@
 
 # Some application helper!?
 module ApplicationHelper
+  # Returns the full title on a per-page basis
+  def page_title(title = '')
+    base_title = "Ruby on Rails Tutorial Sample App"
+    base_title = "#{title} | #{base_title}" if title.present?
+    base_title
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= yield(:title) %> | Ruby on Rails Tutorial Sample App</title>
+    <title><%= page_title(yield(:title)) %></title>
     <%= csrf_meta_tags %>
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,4 +1,3 @@
-<% provide(:title, 'Home') %>
 <h1>Sample App</h1>
 <p>
   This is the home page for the

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -4,30 +4,30 @@ require 'test_helper'
 
 class StaticPagesControllerTest < ActionDispatch::IntegrationTest
   def setup
-    @base_title = '| Ruby on Rails Tutorial Sample App'
+    @base_title = 'Ruby on Rails Tutorial Sample App'
   end
 
   test 'should get home' do
     get static_pages_home_url
     assert_response :success
-    assert_select 'title', "Home #{@base_title}"
+    assert_select 'title', "#{@base_title}"
   end
 
   test 'should get help' do
     get static_pages_help_url
     assert_response :success
-    assert_select 'title', "Help #{@base_title}"
+    assert_select 'title', "Help | #{@base_title}"
   end
 
   test 'should get about' do
     get static_pages_about_url
     assert_response :success
-    assert_select 'title', "About #{@base_title}"
+    assert_select 'title', "About | #{@base_title}"
   end
 
   test 'should get contact' do
     get static_pages_contact_url
     assert_response :success
-    assert_select('title', "Contact #{@base_title}")
+    assert_select('title', "Contact | #{@base_title}")
   end
 end


### PR DESCRIPTION
Helper method to set default page title, if one isn't provided, or construct one.